### PR TITLE
fix: use uniontech's own homepage for network testing

### DIFF
--- a/connectivitychecker.cpp
+++ b/connectivitychecker.cpp
@@ -27,6 +27,7 @@
 #include <QScopedPointer>
 
 static const QStringList CheckUrls {
+    "https://www.uniontech.com",
     "https://www.baidu.com",
     "https://www.bing.com",
     "https://www.google.com",

--- a/networkdevice.cpp
+++ b/networkdevice.cpp
@@ -39,7 +39,7 @@ NetworkDevice::NetworkDevice(const DeviceType type, const QJsonObject &info, QOb
     : QObject(parent),
 
       m_type(type),
-      m_status(Unknow),
+      m_status(Unknown),
       m_deviceInfo(info),
       m_enabled(true)
 {
@@ -48,7 +48,7 @@ NetworkDevice::NetworkDevice(const DeviceType type, const QJsonObject &info, QOb
 
 void NetworkDevice::setDeviceStatus(const int status)
 {
-    DeviceStatus stat = Unknow;
+    DeviceStatus stat = Unknown;
 
     switch (status)
     {
@@ -125,7 +125,7 @@ const QString NetworkDevice::statusStringDetail() const
 
     switch (m_status)
     {
-    case Unknow:
+    case Unknown:
     case Unmanaged:
     case Unavailable: {
         switch (m_type) {

--- a/networkdevice.h
+++ b/networkdevice.h
@@ -51,7 +51,7 @@ public:
 
     enum DeviceStatus
     {
-        Unknow          = 0,
+        Unknown         = 0,
         Unmanaged       = 10,
         Unavailable     = 20,
         Disconnected    = 30,


### PR DESCRIPTION
We should not depend on a third-party for this, and I believe it's considered abusive. Put some faith in our own infrastructure!